### PR TITLE
update deprecated preg_replace call, remove PHP closing tags

### DIFF
--- a/Mogreet.php
+++ b/Mogreet.php
@@ -31,7 +31,7 @@ class Mogreet
     private $token;
     private $defaultFormat;
 
-    public function __construct($clientId, $token) 
+    public function __construct($clientId, $token)
     {
         $this->clientId      = $clientId;
         $this->token         = $token;
@@ -44,7 +44,7 @@ class Mogreet
         $this->list          = new Mogreet_List($this);
     }
 
-    public function processRequest($base, $api, array $params = array(), $multipart = false) 
+    public function processRequest($base, $api, array $params = array(), $multipart = false)
     {
         // TODO implement flag to do post/get
         $params = array_merge($params, $this->_getDefaultApiParams());
@@ -52,10 +52,8 @@ class Mogreet
         return new Mogreet_Response($params['format'], $data);
     }
 
-    protected function _getDefaultApiParams() 
+    protected function _getDefaultApiParams()
     {
         return [ "client_id" => $this->clientId, "token" => $this->token, "format" => $this->defaultFormat ];
     }
 }
-
-?>

--- a/lib/Exception.php
+++ b/lib/Exception.php
@@ -1,6 +1,6 @@
 <?php
 
-class Mogreet_Exception 
+class Mogreet_Exception
     extends Exception
 {
     protected $api;
@@ -13,15 +13,13 @@ class Mogreet_Exception
         parent::__construct($message, $code);
     }
 
-    public function getApi() 
+    public function getApi()
     {
         return $this->api;
     }
 
-    public function getParams() 
+    public function getParams()
     {
         return $this->params;
     }
 }
-
-?>

--- a/lib/Keyword.php
+++ b/lib/Keyword.php
@@ -1,6 +1,6 @@
 <?php
 
-class Mogreet_Keyword 
+class Mogreet_Keyword
 {
     private $client;
 
@@ -9,7 +9,7 @@ class Mogreet_Keyword
         $this->client = $client;
     }
 
-    public function listAll(array $params = array()) 
+    public function listAll(array $params = array())
     {
         return $this->client->processRequest('cm', 'keyword.list', $params);
     }
@@ -17,18 +17,16 @@ class Mogreet_Keyword
     public function check(array $params = array())
     {
         return $this->client->processRequest('cm', 'keyword.check', $params);
-    } 
+    }
 
     public function add(array $params = array())
     {
         return $this->client->processRequest('cm', 'keyword.add', $params);
-    } 
+    }
 
     public function remove(array $params = array())
     {
         return $this->client->processRequest('cm', 'keyword.remove', $params);
-    } 
+    }
 
 }
-
-?>

--- a/lib/List.php
+++ b/lib/List.php
@@ -1,6 +1,6 @@
 <?php
 
-class Mogreet_List 
+class Mogreet_List
 {
     private $client;
 
@@ -9,50 +9,48 @@ class Mogreet_List
         $this->client = $client;
     }
 
-    public function destroy(array $params = array()) 
+    public function destroy(array $params = array())
     {
         return $this->client->processRequest('cm', 'list.destroy', $params);
     }
 
-    public function pruneAll(array $params = array()) 
+    public function pruneAll(array $params = array())
     {
         return $this->client->processRequest('cm', 'list.empty', $params);
     }
 
-    public function download(array $params = array()) 
+    public function download(array $params = array())
     {
         return $this->client->processRequest('cm', 'list.download', $params);
     }
 
-    public function send(array $params = array()) 
+    public function send(array $params = array())
     {
         return $this->client->processRequest('cm', 'list.send', $params);
     }
 
-    public function prune(array $params = array()) 
+    public function prune(array $params = array())
     {
         return $this->client->processRequest('cm', 'list.prune', $params);
     }
 
-    public function append(array $params = array()) 
+    public function append(array $params = array())
     {
         return $this->client->processRequest('cm', 'list.append', $params);
     }
 
-    public function create(array $params = array()) 
+    public function create(array $params = array())
     {
         return $this->client->processRequest('cm', 'list.create', $params);
     }
 
-    public function listAll(array $params = array()) 
+    public function listAll(array $params = array())
     {
         return $this->client->processRequest('cm', 'list.list', $params);
     }
 
-    public function info(array $params = array()) 
+    public function info(array $params = array())
     {
         return $this->client->processRequest('cm', 'list.info', $params);
     }
 }
-
-?>

--- a/lib/Media.php
+++ b/lib/Media.php
@@ -1,6 +1,6 @@
 <?php
 
-class Mogreet_Media 
+class Mogreet_Media
 {
     private $client;
 
@@ -9,7 +9,7 @@ class Mogreet_Media
         $this->client = $client;
     }
 
-    public function remove($contentId, array $params = array()) 
+    public function remove($contentId, array $params = array())
     {
         return $this->client->processRequest('cm', 'media.remove', $params);
     }
@@ -19,7 +19,7 @@ class Mogreet_Media
         return $this->client->processRequest('cm', 'media.list', $params);
     }
 
-    public function upload(array $params = array()) 
+    public function upload(array $params = array())
     {
         if (isset($params['file'])) {
             // uploading a file located on the server
@@ -31,5 +31,3 @@ class Mogreet_Media
         return $this->client->processRequest('cm', 'media.upload', $params, true);
     }
 }
-
-?>

--- a/lib/Request.php
+++ b/lib/Request.php
@@ -1,6 +1,6 @@
 <?php
 
-class Mogreet_Request 
+class Mogreet_Request
 {
     private static $_requiredParams = array(
         'system.ping'        => array(),
@@ -39,7 +39,7 @@ class Mogreet_Request
         }
     }
 
-    public static function postRequest($base, $api, $params, $multipart) 
+    public static function postRequest($base, $api, $params, $multipart)
     {
         Mogreet_Request::_checkParams($api, $params);
 
@@ -66,5 +66,3 @@ class Mogreet_Request
         return $data;
     }
 }
-
-?>

--- a/lib/Response.php
+++ b/lib/Response.php
@@ -1,33 +1,31 @@
 <?php
 
-class Mogreet_Response 
+class Mogreet_Response
 {
     private $format;
     private $data;
     private $obj;
 
-    public function __construct($format, $data) 
+    public function __construct($format, $data)
     {
         $this->format = $format;
         $this->data = $data;
         $this->buildObjectFromJson();
     }
 
-    protected function buildObjectFromJson() 
+    protected function buildObjectFromJson()
     {
         /* $this->obj = json_decode($this->data); */
         $this->obj = Mogreet_Utils::json_to_object(json_decode($this->data, true));
     }
 
-    public function __get($property) 
+    public function __get($property)
     {
         return $this->obj->response->$property;
     }
 
-    public function __toString() 
+    public function __toString()
     {
         return $this->data;
     }
 }
-
-?>

--- a/lib/System.php
+++ b/lib/System.php
@@ -1,6 +1,6 @@
 <?php
 
-class Mogreet_System 
+class Mogreet_System
 {
     private $client;
 
@@ -9,10 +9,8 @@ class Mogreet_System
         $this->client = $client;
     }
 
-    public function ping(array $params = array()) 
+    public function ping(array $params = array())
     {
         return $this->client->processRequest('moms', 'system.ping', $params);
     }
 }
-
-?>

--- a/lib/Transaction.php
+++ b/lib/Transaction.php
@@ -1,6 +1,6 @@
 <?php
 
-class Mogreet_Transaction 
+class Mogreet_Transaction
 {
     protected $client;
 
@@ -9,7 +9,7 @@ class Mogreet_Transaction
         $this->client = $client;
     }
 
-    public function send(array $params = array()) 
+    public function send(array $params = array())
     {
         return $this->client->processRequest('moms', 'transaction.send', $params);
     }
@@ -17,7 +17,5 @@ class Mogreet_Transaction
     public function lookup(array $params = array())
     {
         return $this->client->processRequest('moms', 'transaction.lookup', $params);
-    } 
+    }
 }
-
-?>

--- a/lib/User.php
+++ b/lib/User.php
@@ -1,6 +1,6 @@
 <?php
 
-class Mogreet_User 
+class Mogreet_User
 {
     private $client;
 
@@ -9,30 +9,28 @@ class Mogreet_User
         $this->client = $client;
     }
 
-    public function transactions(array $params = array()) 
+    public function transactions(array $params = array())
     {
         return $this->client->processRequest('moms', 'user.transactions', $params);
     }
 
-    public function getopt(array $params = array()) 
+    public function getopt(array $params = array())
     {
         return $this->client->processRequest('moms', 'user.getopt', $params);
     }
 
-    public function info(array $params = array()) 
+    public function info(array $params = array())
     {
         return $this->client->processRequest('moms', 'user.info', $params);
     }
 
-    public function lookup(array $params = array()) 
+    public function lookup(array $params = array())
     {
         return $this->client->processRequest('moms', 'user.lookup', $params);
     }
 
-    public function uncache(array $params = array()) 
+    public function uncache(array $params = array())
     {
         return $this->client->processRequest('moms', 'user.uncache', $params);
     }
 }
-
-?>

--- a/lib/Utils.php
+++ b/lib/Utils.php
@@ -3,9 +3,15 @@
 class Mogreet_Utils
 {
 
-    public static function toCamelCase($str) 
+    public static function toCamelCase($str)
     {
-        return preg_replace('/_([a-z])/e', "strtoupper('\\1')", $str);
+        return preg_replace_callback(
+            '/_([a-z])/',
+            function ($matches) {
+                return strtoupper($matches[0]);
+            },
+            $str
+        );
     }
 
     public static function fromCamelCase($str)
@@ -42,5 +48,3 @@ class Mogreet_Utils
         return $obj;
     }
 }
-
-?>


### PR DESCRIPTION
Fixes an error that "/e" is now deprecated in preg_replace.

Removing the closing ?> tags prevents potential "headers already sent" error due to the white space after the closing tags.
